### PR TITLE
T17805 adjust the name of the permissions when defining gates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,9 +2,9 @@ name: run-tests
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   test:
@@ -12,13 +12,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.0]
-        laravel: [8.*]
-        stability: [prefer-lowest, prefer-stable]
+        os: [ ubuntu-latest, windows-latest ]
+        php: [ 8.0 ]
+        laravel: [ 8.* ]
+        stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 8.*
-            testbench: ^6.6
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
         stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 8.*
-            testbench: 6.*
+            testbench: ^6.25
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/src/GsvAuth0Provider.php
+++ b/src/GsvAuth0Provider.php
@@ -136,6 +136,10 @@ class GsvAuth0Provider
 
                     foreach ($permission as $appPermission) {
                         $ability = (string)Str::of($applicationKey)->append('::')->append($appPermission);
+
+                        // in order to keep backwards compatibility
+                        // we add both the application specific permission and the one without app prefix(old logic).
+                        $permissions[] = $appPermission;
                         $permissions[] = $ability;
                     }
 

--- a/src/GsvAuth0Provider.php
+++ b/src/GsvAuth0Provider.php
@@ -5,8 +5,10 @@ namespace Adaptdk\GsvAuth0Provider;
 use Adaptdk\GsvAuth0Provider\Exceptions\InvalidTokenException;
 use Adaptdk\GsvAuth0Provider\Exceptions\UserNotFoundException;
 use Adaptdk\GsvAuth0Provider\Models\Auth0User;
+use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 
 class GsvAuth0Provider
 {
@@ -46,11 +48,11 @@ class GsvAuth0Provider
     public function authenticate(string $token): self
     {
         if ($this->auth0_domain === null) {
-            throw new \Exception('Auth0 domain not set');
+            throw new Exception('Auth0 domain not set');
         }
 
         if ($this->api_identifier === null) {
-            throw new \Exception('API identifier not set');
+            throw new Exception('API identifier not set');
         }
 
         try {
@@ -128,6 +130,20 @@ class GsvAuth0Provider
 
         collect($user->abilities)
             ->merge(auth()->user()->permission ?? [])
+            ->map(function ($permission, $applicationKey) {
+                if (is_array($permission)) {
+                    $permissions = [];
+
+                    foreach ($permission as $appPermission) {
+                        $ability = (string)Str::of($applicationKey)->append('::')->append($appPermission);
+                        $permissions[] = $ability;
+                    }
+
+                    return $permissions;
+                }
+
+                return $permission;
+            })
             ->flatten()
             ->unique()
             ->each(function ($permission) {


### PR DESCRIPTION
This PR adjusts how the user permissions is mapped to Laravel gate definitions. 
Before it didnt take the application into consideration which is a problem so only the last bit of the permission name is actually mapped. 
`dashboard::deleteUsers` => would be mapped to just `updateUsers`.